### PR TITLE
[TASK] Mark compatibility to php 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	},
 	"require": {
-		"php": ">=7.0 <7.4",
+		"php": ">=7.0 <7.5",
 		"symfony/yaml": "^2.7 || ^3.0 || ^4.0",
 		"typo3/cms-core": "^7.6 || ^8.7 || ^9.0",
 		"helhum/typo3-console": "^4.0 || ^5.0"


### PR DESCRIPTION
This will increase the compatibility for PHP to 7.4.

We are using it already with this version and we are not faced with issues.