### PR TITLE
[BUGFIX] Append, don't prepend, imports from yaml

### DIFF
--- a/src/Command/SiteImportCommandController.php
+++ b/src/Command/SiteImportCommandController.php
@@ -101,7 +101,7 @@ class SiteImportCommandController extends CommandController
                 $importedContent = Yaml::parseFile($import['resource']);
                 if (! empty($importedContent) && is_array($importedContent)) {
                     $importedContent = $this->loadImports($importedContent);
-                    $contents = array_merge($importedContent, $contents);
+                    $contents = array_merge($contents, $importedContent);
                 }
             }
             unset($contents['imports']);


### PR DESCRIPTION
When processing imports the call to array_merge adds
the imports before the already processed yaml data,
which causes unexpected order of the final results.

Symptom is that it is not possible to control the order
of the imports since they will effectively be imported in
reverse order:

* Import file A
* Import file B
* Import file C

Causes order in processed yaml:

* Imports from file C
* Imports from file B
* Imports from file A

In normal circumstances this doesn't matter much, but
in cases where for example file A defines some entries
with mode=replace in order to create a starting data
set and files B and C define partial data sets with
mode=update, the partial updates will be processed first
and then get truncated because file A is processed last.

Switching the order of parameters for array_merge solves
the problem by ensuring that the order of import definitions
is preserved in the processed yaml.