### PR TITLE
[BUGFIX] Ignore empty data sets

### DIFF
--- a/src/Command/SiteImportCommandController.php
+++ b/src/Command/SiteImportCommandController.php
@@ -41,7 +41,7 @@ class SiteImportCommandController extends CommandController
                     $conn->truncate($config['table']);
                     $this->outputLine('Emptied database table "' . $config['table'] . '"');
                 }
-                foreach ($config['entries'] as $entry) {
+                foreach ($config['entries'] ?? [] as $entry) {
                     if ($mode === 'update' && isset($entry['uid'])) {
                         $identifiers = ['uid' => $entry['uid']];
                         if ($conn->count('uid', $config['table'], $identifiers)) {
@@ -67,7 +67,7 @@ class SiteImportCommandController extends CommandController
                     $conn->exec_TRUNCATEquery($config['table']);
                     $this->outputLine('Emptied database table "' . $config['table'] . '"');
                 }
-                foreach ($config['entries'] as $entry) {
+                foreach ($config['entries'] ?? [] as $entry) {
                     if ($mode === 'update' && isset($entry['uid'])) {
                         $condition = sprintf('uid = %d', $entry['uid']);
                         if ($conn->exec_SELECTcountRows('uid', $config['table'], $condition)) {


### PR DESCRIPTION
Ignores data sets which don't have any "entries", which
in turn allows a data set to define mode=replace to
cause a truncate of the table without adding any new
records to it.

Useful in cases where several partial data sets are added
with mode=update, but where an initial truncate is wanted
in order to clear the table before processing the partial
data sets.